### PR TITLE
Implement basic failure notification propagation

### DIFF
--- a/proto/torchft.proto
+++ b/proto/torchft.proto
@@ -8,6 +8,7 @@ syntax = "proto3";
 package torchft;
 
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/empty.proto";
 
 message RaftMessageRequest {
     // Request message contains the serialized Raft proto message.
@@ -67,9 +68,14 @@ message LighthouseHeartbeatRequest {
 
 message LighthouseHeartbeatResponse {}
 
+message FailureNotification {
+    string replica_id = 1;
+}
+
 service LighthouseService {
     rpc Quorum (LighthouseQuorumRequest) returns (LighthouseQuorumResponse);
     rpc Heartbeat (LighthouseHeartbeatRequest) returns (LighthouseHeartbeatResponse);
+    rpc WatchFailures (google.protobuf.Empty) returns (stream FailureNotification);
 }
 
 message ManagerQuorumRequest {
@@ -125,4 +131,5 @@ service ManagerService {
     rpc CheckpointMetadata(CheckpointMetadataRequest) returns (CheckpointMetadataResponse);
     rpc ShouldCommit(ShouldCommitRequest) returns (ShouldCommitResponse);
     rpc Kill(KillRequest) returns (KillResponse);
+    rpc FailureNotifications(google.protobuf.Empty) returns (stream FailureNotification);
 }

--- a/torchft/_torchft.pyi
+++ b/torchft/_torchft.pyi
@@ -22,6 +22,7 @@ class ManagerClient:
         should_commit: bool,
         timeout: timedelta,
     ) -> bool: ...
+    def next_failure(self, timeout: timedelta) -> Optional[str]: ...
 
 class QuorumResult:
     quorum_id: int


### PR DESCRIPTION
## Summary
- extend protobuf with `FailureNotification` message and streaming RPCs
- push missed-heartbeat failures from Lighthouse to Managers
- expose failure notifications via ManagerService and Python bindings
- add background thread in `Manager` to abort PG on failure notice

## Testing
- `cargo test` *(fails: failed to download crates)*
- `pytest` *(fails: command not found)*