### PR TITLE
Add abort timeout test and adjust subscribe_failures

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,8 @@
+# Plan
+* [x] Add `FailureNotification` message and `SubscribeFailures` RPC to `proto/torchft.proto`.
+* [x] Lighthouse server monitors heartbeat expirations and broadcasts `FailureNotification`.
+* [x] Expose streaming RPC in Rust bindings and Python `LighthouseClient` via `subscribe_failures()`.
+* [x] Manager creates a `LighthouseClient`, starts a listener thread, and logs received failures.
+* [x] Write tests that heartbeat timeouts trigger a failure notification.
+* [x] Remove `py.allow_threads` usage from the new `subscribe_failures` binding.
+* [x] Add integration test measuring process group abort time when a manager dies.

--- a/proto/torchft.proto
+++ b/proto/torchft.proto
@@ -67,9 +67,14 @@ message LighthouseHeartbeatRequest {
 
 message LighthouseHeartbeatResponse {}
 
+message FailureNotification {
+    string replica_id = 1;
+}
+
 service LighthouseService {
     rpc Quorum (LighthouseQuorumRequest) returns (LighthouseQuorumResponse);
     rpc Heartbeat (LighthouseHeartbeatRequest) returns (LighthouseHeartbeatResponse);
+    rpc SubscribeFailures (google.protobuf.Empty) returns (stream FailureNotification);
 }
 
 message ManagerQuorumRequest {

--- a/torchft/_torchft.pyi
+++ b/torchft/_torchft.pyi
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Hashable, List, Optional
+from typing import Hashable, List, Optional, Iterator
 
 class ManagerClient:
     def __init__(self, addr: str, connect_timeout: timedelta) -> None: ...
@@ -86,6 +86,10 @@ class Quorum:
     created: Timestamp
 
 @dataclass
+class FailureNotification:
+    replica_id: str
+
+@dataclass
 class LighthouseClient:
     addr: str
     connect_timeout: timedelta
@@ -106,3 +110,4 @@ class LighthouseClient:
         replica_id: str,
         timeout: timedelta = timedelta(seconds=5),
     ) -> None: ...
+    def subscribe_failures(self) -> Iterator[FailureNotification]: ...

--- a/torchft/abort_timeout_integ_test.py
+++ b/torchft/abort_timeout_integ_test.py
@@ -1,0 +1,73 @@
+import multiprocessing
+import time
+from datetime import timedelta
+from unittest import TestCase
+
+import torch
+import torch.distributed as dist
+
+from torchft._torchft import LighthouseServer
+from torchft.manager import Manager
+from torchft.process_group import ProcessGroupGloo
+
+
+def _worker(rank: int, store_port: int, lighthouse_addr: str, q: multiprocessing.Queue) -> None:
+    pg = ProcessGroupGloo()
+    manager = Manager(
+        pg=pg,
+        min_replica_size=2,
+        load_state_dict=lambda x: None,
+        state_dict=lambda: None,
+        replica_id=str(rank),
+        store_addr="localhost",
+        store_port=store_port,
+        rank=rank,
+        world_size=2,
+        lighthouse_addr=lighthouse_addr,
+        port=19530 + rank,
+        timeout=timedelta(minutes=2),
+        use_async_quorum=False,
+    )
+    try:
+        manager.start_quorum()
+        while True:
+            t = torch.ones(1)
+            fut = manager.allreduce(t)
+            fut.wait()
+            time.sleep(1)
+    except Exception:
+        q.put(time.time())
+    finally:
+        manager.shutdown(wait=False)
+
+
+class AbortTimeoutIntegTest(TestCase):
+    def test_abort_timeout(self) -> None:
+        lighthouse = LighthouseServer(bind="[::]:0", min_replicas=2)
+        store = dist.TCPStore(
+            host_name="localhost",
+            port=0,
+            is_master=True,
+            wait_for_workers=False,
+        )
+
+        ctx = multiprocessing.get_context("spawn")
+        q: multiprocessing.Queue[float] = ctx.Queue()
+        p0 = ctx.Process(target=_worker, args=(0, store.port, lighthouse.address(), q))
+        p1 = ctx.Process(target=_worker, args=(1, store.port, lighthouse.address(), q))
+        p0.start()
+        p1.start()
+
+        time.sleep(2)
+        kill_time = time.time()
+        p0.kill()
+
+        abort_time = q.get(timeout=180)
+        duration = abort_time - kill_time
+
+        lighthouse.shutdown()
+        p1.join(timeout=10)
+        p0.join(timeout=10)
+
+        self.assertLess(duration, 150)
+


### PR DESCRIPTION
## Summary
- remove the `py.allow_threads` wrapper from the new `subscribe_failures` binding
- expose required `Empty` import for the streaming call
- add an integration test that measures how quickly a remaining rank aborts once its partner process exits
- update plan with the completed tasks

## Testing
- `cargo build --quiet --locked` *(fails: failed to download crates)*
- `pytest -q` *(fails: command not found)*