### PR TITLE
Fix subscribe_failures stream iterator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ mod timeout;
 use anyhow::Result;
 use atty::Stream;
 use core::time::Duration;
-use pyo3::exceptions::{PyRuntimeError, PyTimeoutError};
+use pyo3::exceptions::{PyRuntimeError, PyTimeoutError, PyStopIteration};
 use std::cmp;
 use std::env;
 use std::sync::Arc;
@@ -41,6 +41,7 @@ use crate::torchftpb::{
 };
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
+use pyo3::{PyRef, PyRefMut};
 
 // Get the number of threads to use for the tokio runtime
 fn num_threads() -> usize {
@@ -291,6 +292,28 @@ struct QuorumResult {
     heal: bool,
 }
 
+#[pyclass(unsendable)]
+struct FailureStream {
+    runtime: Arc<Runtime>,
+    stream: tonic::Streaming<torchftpb::FailureNotification>,
+}
+
+#[pymethods]
+impl FailureStream {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __next__(mut slf: PyRefMut<'_, Self>) -> PyResult<FailureNotificationPy> {
+        let runtime = slf.runtime.clone();
+        match runtime.block_on(slf.stream.next()) {
+            Some(Ok(note)) => Ok(FailureNotificationPy { replica_id: note.replica_id }),
+            Some(Err(status)) => Err(StatusError(status).into()),
+            None => Err(PyStopIteration::new_err(())),
+        }
+    }
+}
+
 #[pymethods]
 impl QuorumResult {
     #[new]
@@ -397,6 +420,12 @@ pub struct Timestamp {
     pub nanos: i32,
 }
 
+#[pyclass(get_all, set_all)]
+#[derive(Clone)]
+struct FailureNotificationPy {
+    replica_id: String,
+}
+
 /// quorum result.
 ///
 /// Args:
@@ -479,7 +508,7 @@ fn convert_quorum(py: Python, q: &torchftpb::Quorum) -> PyResult<Quorum> {
 #[pyclass]
 struct LighthouseClient {
     client: LighthouseServiceClient<Channel>,
-    runtime: Runtime,
+    runtime: Arc<Runtime>,
 }
 
 #[pymethods]
@@ -488,11 +517,11 @@ impl LighthouseClient {
     #[new]
     fn new(py: Python<'_>, addr: String, connect_timeout: Duration) -> PyResult<Self> {
         py.allow_threads(move || {
-            let runtime = tokio::runtime::Builder::new_multi_thread()
+            let runtime = Arc::new(tokio::runtime::Builder::new_multi_thread()
                 .worker_threads(num_threads())
                 .thread_name("torchft-lhclnt")
                 .enable_all()
-                .build()?;
+                .build()?);
             let client = runtime
                 .block_on(manager::lighthouse_client_new(addr, connect_timeout))
                 .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
@@ -589,44 +618,23 @@ impl LighthouseClient {
     }
 
     #[pyo3(signature = (timeout = Duration::from_secs(5)))]
-    fn subscribe_failures(&self,
+    fn subscribe_failures(
+        &self,
         py: Python<'_>,
-        timeout: Duration
-    ) -> PyResult<()> {
-        // 1) Build the tonic request
-        let mut req = tonic::Request::new(SubscribeFailuresRequest {});
-        req.set_timeout(timeout);
-        println!("subscribe_failures called");
-    
-        // 2) Execute all blocking work outside the GIL
-        let result: PyResult<()> = py.allow_threads(move || {
-            // a) Invoke the streaming RPC
-            println!("invoke streaming RPC");
+        timeout: Duration,
+    ) -> PyResult<FailureStream> {
+        py.allow_threads(move || {
+            let mut req = tonic::Request::new(SubscribeFailuresRequest {});
+            req.set_timeout(timeout);
             let response = self
                 .runtime
                 .block_on(self.client.clone().subscribe_failures(req))
                 .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
-            // b) Take the inner stream
-            println!("take inner stream");
-            let mut stream = response.into_inner();
-            // c) Pull from the stream asynchronously
-            println!("pull from stream asynchronously");
-            self.runtime
-                .block_on(async move {
-                    while let Some(item) = stream.next().await {
-                        let failure = item?;
-                        // Replace with actual handling (e.g., Python callback)
-                        println!("Received failure: {:?}", failure);
-                    }
-                    Ok::<(), tonic::Status>(())
-                })
-                .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
-            println!("done");
-            Ok(())
-        });
-    
-        // 3) Convert any errors into PyRuntimeError
-        result.map_err(|e| PyRuntimeError::new_err(e.to_string()))
+            Ok(FailureStream {
+                runtime: self.runtime.clone(),
+                stream: response.into_inner(),
+            })
+        })
     }
 }
 
@@ -795,6 +803,8 @@ fn _torchft(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<LighthouseServer>()?;
     m.add_class::<LighthouseClient>()?;
     m.add_class::<QuorumResult>()?;
+    m.add_class::<FailureNotificationPy>()?;
+    m.add_class::<FailureStream>()?;
     m.add_function(wrap_pyfunction!(lighthouse_main, m)?)?;
 
     Ok(())

--- a/torchft/_torchft.pyi
+++ b/torchft/_torchft.pyi
@@ -11,7 +11,6 @@ class ManagerClient:
         checkpoint_metadata: str,
         shrink_only: bool,
         timeout: timedelta,
-        commit_failures: int,
         init_sync: bool = True,
     ) -> QuorumResult: ...
     def _checkpoint_metadata(self, rank: int, timeout: timedelta) -> str: ...
@@ -35,7 +34,6 @@ class QuorumResult:
     max_replica_rank: Optional[int]
     max_world_size: int
     heal: bool
-    commit_failures: int
 
 class ManagerServer:
     def __init__(
@@ -86,6 +84,14 @@ class Quorum:
     created: Timestamp
 
 @dataclass
+class FailureNotification:
+    replica_id: str
+
+class FailureStream:
+    def __iter__(self) -> "FailureStream": ...
+    def __next__(self) -> FailureNotification: ...
+
+@dataclass
 class LighthouseClient:
     addr: str
     connect_timeout: timedelta
@@ -106,3 +112,7 @@ class LighthouseClient:
         replica_id: str,
         timeout: timedelta = timedelta(seconds=5),
     ) -> None: ...
+    def subscribe_failures(
+        self,
+        timeout: timedelta = timedelta(seconds=5),
+    ) -> FailureStream: ...

--- a/torchft/lighthouse_test.py
+++ b/torchft/lighthouse_test.py
@@ -169,16 +169,14 @@ class TestLighthouse(TestCase):
                 connect_timeout=timedelta(seconds=1),
             )
             print("client created")
-            # call = client.subscribe_failures(timeout=timedelta(milliseconds=100))
+            stream = client.subscribe_failures(timeout=timedelta(milliseconds=100))
             print("subscribe_failures called")
-            # start = time.time()
-            # with self.assertRaises(grpc.RpcError) as ctx:
-            #     next(call)                # this blocks until the 100 ms deadline
-            # elapsed = time.time() - start
-            # self.assertLess(elapsed, 0.5)
-            # self.assertGreater(elapsed, 0.05)
-            # self.assertEqual(ctx.exception.code(), grpc.StatusCode.DEADLINE_EXCEEDED)
-            self.assertTrue(True)
+            start = time.time()
+            with self.assertRaises(Exception):
+                next(stream)
+            elapsed = time.time() - start
+            self.assertLess(elapsed, 0.5)
+            self.assertGreater(elapsed, 0.05)
         finally:
             print("lighthouse shutdown")
             lighthouse.shutdown()
@@ -201,18 +199,16 @@ class TestLighthouse(TestCase):
                 connect_timeout=timedelta(seconds=1),
             )
             print("client created")
-            # Test with a very short timeout that should trigger
             start_time = time.time()
+            stream = client.subscribe_failures(timeout=timedelta(milliseconds=100))
             with self.assertRaises(Exception) as context:
-                client.subscribe_failures(timeout=timedelta(milliseconds=100))
+                next(stream)
             end_time = time.time()
             print("subscribe_failures called")
-            # Verify that the operation took approximately the timeout duration
             time_taken = end_time - start_time
-            self.assertLess(time_taken, 0.5)  # Should be close to 100ms but allow some buffer
-            self.assertGreater(time_taken, 0.05)  # Should be at least 50ms
+            self.assertLess(time_taken, 0.5)
+            self.assertGreater(time_taken, 0.05)
             print("subscribe_failures done")
-            # Verify that the error is a timeout error
             self.assertIn("timeout", str(context.exception).lower())
             print("subscribe_failures done")
         finally:


### PR DESCRIPTION
## Summary
- import `PyStopIteration` and drop unused `Streaming` import
- mark `FailureStream` as `unsendable` and fix borrowing in `__next__`
- remove obsolete `commit_failures` hints from the Python stubs

## Testing
- `cargo check --offline -q` *(fails: no matching package named `anyhow`)*
- `pytest -q` *(fails: command not found)*